### PR TITLE
avoid RESTEasy server + fix Retrofit usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-Quarkiverse Apicurio Registry Client is a Quarkus extension that provides the REST client to interact with [Apicurio Registry](https://www.apicur.io/registry/)
+Quarkiverse Apicurio Registry Client is a Quarkus extension that provides the REST client to interact with [Apicurio Registry](https://www.apicur.io/registry/).
 
 Apicurio Registry is a Schema and API registry useful to store AVRO schemas, OpenAPI designs, and many more formats ...
 
 This Quarkus extension provides the REST client dependency to interact with Apicurio Registry allowing your Quarkus applications to compile to native and still interact with Apicurio Registry.
+
+This Quarkus extension is meant to be used with Apicurio Registry 1.x libraries (such as `io.apicurio:apicurio-registry-utils-serde`), especially with the 1.3.x releases that use Retrofit.
+It is _not_ necessary for Apicurio Registry 2.x libraries (such as `io.apicurio:apicurio-registry-serdes-avro-serde`).
 
 ## Contributors ✨
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -13,26 +13,24 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkiverse.apicurio</groupId>
             <artifactId>quarkiverse-apicurio-registry-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin-deployment</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,15 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
 
         <apicurio.client.version>1.3.2.Final</apicurio.client.version>
-        <camel.quarkus.version>1.4.0</camel.quarkus.version>
+        <kotlinx.coroutines.version>1.4.3</kotlinx.coroutines.version>
+        <retrofit2.version>2.9.0</retrofit2.version> <!-- corresponds to what Apicurio Registry 1.3.2.Final uses -->
     </properties>
 
     <modules>
         <module>deployment</module>
         <module>runtime</module>
     </modules>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -48,21 +50,19 @@
                 <artifactId>apicurio-registry-rest-client</artifactId>
                 <version>${apicurio.client.version}</version>
             </dependency>
-
             <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-support-retrofit</artifactId>
-                <version>${camel.quarkus.version}</version>
+                <groupId>com.squareup.retrofit2</groupId>
+                <artifactId>retrofit</artifactId>
+                <version>${retrofit2.version}</version>
             </dependency>
-
             <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-                <version>${camel.quarkus.version}</version>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+                <version>${kotlinx.coroutines.version}</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -12,22 +12,44 @@
     <name>Apicurio Registry client - Runtime</name>
 
     <dependencies>
-
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-rest-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+        </dependency>
+        <!-- Retrofit 2.9.0 includes Kotlin extension functions, some of them suspending -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-support-retrofit</artifactId>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/runtime/src/main/java/io/quarkiverse/apicurio/runtime/graal/RetrofitSubstitutions.java
+++ b/runtime/src/main/java/io/quarkiverse/apicurio/runtime/graal/RetrofitSubstitutions.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.apicurio.runtime.graal;
+
+import java.lang.reflect.Method;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+// substitutions for Retrofit 2.9.0, the version used by Apicurio Registry 1.3.2.Final client libraries
+
+@TargetClass(className = "retrofit2.Platform")
+final class Target_retrofit2_Platform {
+    @Substitute
+    private static Target_retrofit2_Platform findPlatform() {
+        return new Target_retrofit2_Platform(true);
+    }
+
+    @Alias
+    private boolean hasJava8Types;
+
+    @Substitute
+    Target_retrofit2_Platform(boolean hasJava8Types) {
+        this.hasJava8Types = hasJava8Types;
+    }
+
+    @Substitute
+    Object invokeDefaultMethod(Method method, Class<?> declaringClass, Object object, Object... args) throws Throwable {
+        method.setAccessible(true);
+        return method.invoke(object, args);
+    }
+}
+
+class RetrofitSubstitutions {
+}


### PR DESCRIPTION
The Apicurio Registry 1.x client libraries use JAX-RS Client and
Retrofit as HTTP clients. For JAX-RS Client, we need RESTEasy,
but not the full RESTEasy server; the client is enough. Unfortunately
Quarkus doesn't have an extension for pure RESTEasy Client, so here
we use `quarkus-rest-client`, which brings MicroProfile RestClient.
Compared to bringing full RESTEasy server, this is neglibile.

Retrofit works standalone and without an issue on JVM, but requires
some substitutions for native compilation. Previously, we used to
depend on a Camel Quarkus extension for this, but that depends on
an older Retrofit version (2.5.0). Apicurio Registry 1.x libraries
depend on a newer Retrofit version (2.9.0), so here we remove
the dependency on Camel Quarkus and implement the substitutions
for Retrofit ourselves. Compared to the Camel Quarkus extension,
the substitutions here are much smaller.

All in all, with these changes, using the Apicurio Registry 1.x
client libraries in Quarkus native projects become much easier.